### PR TITLE
Add meta sdk flag to track usage of npm packages

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -121,9 +121,11 @@ export const initStripeConnect = (
 const createWrapper = (stripeConnect: any) => {
   const wrapper: StripeConnectWrapper = {
     initialize: (params: IStripeConnectInitParams) => {
+      const metaOptions = (params as any).metaOptions ?? {};
       stripeConnect.init({
         ...params,
         metaOptions: {
+          ...metaOptions,
           sdk: true
         }
       });


### PR DESCRIPTION
This adds a sdk flag: boolean that is set to true if developers are initializing Connect.js through npm package

r? @jorgea-stripe 