### PR TITLE
Remove uiconfig option from update API

### DIFF
--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -16,7 +16,6 @@ export declare type AppearanceOptions = {
 
 export type IStripeConnectUpdateParams = {
   appearance?: AppearanceOptions;
-  uiConfig?: UIConfigOptions;
 };
 
 export interface IStripeConnectInitParams {


### PR DESCRIPTION
Removes the UIConfig option as there aren't any use cases for changing overlay type at run time

r? @slye-stripe 