### PR TITLE
Add locale as a supported parameter when initializing ConnectJS

### DIFF
--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -22,6 +22,7 @@ export interface IStripeConnectInitParams {
   appearance?: AppearanceOptions;
   uiConfig?: UIConfigOptions;
   refreshClientSecret?: () => Promise<string>;
+  locale?: string;
 }
 
 export interface StripeConnectWrapper {


### PR DESCRIPTION
We [have shipped `locale` support](https://stripe.com/docs/connect/get-started-connect-embedded-components), so adding `locale` to the list of ConnectJS supported parameters.