### PR TITLE
Add a pure.d.ts to fix typescript definitions when importing /pure version of the package

### DIFF
--- a/pure.d.ts
+++ b/pure.d.ts
@@ -1,0 +1,4 @@
+import { LoadConnect } from "./src/shared";
+
+export declare const loadConnect: LoadConnect;
+export * from "./types/shared";


### PR DESCRIPTION
Noticed that the `pure` imports were broken with typescript. With this update, the imports work now.

Note: the file is already included in the `files` of the `package.json`, but was not int he repository itself.