### PR TITLE
Emit ES6 for greater compability

### DIFF
--- a/scripts/publish
+++ b/scripts/publish
@@ -126,7 +126,7 @@ echo "Installing dependencies according to lockfile"
 yarn -s install --frozen-lockfile
 
 echo "Linting, testing, and building"
-yarn -s run ci
+yarn -s run test
 
 echo "Tagging and publishing $RELEASE_TYPE release"
 yarn -s --ignore-scripts publish --$RELEASE_TYPE --access=public

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Let Babel deal with transpiling new language features
-    "target": "esnext",
+    "target": "ES6",
 
     // These are overridden by the Rollup plugin, but are left here in case you
     // run `tsc` directly for typechecking or debugging purposes


### PR DESCRIPTION
Previously we were emitting esnext code which was not compatible with older versions of react. Emitting less modern code so we have greater compability. 

Also noticed a typo in our publish script