### PR TITLE
[docs] Add versioning note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 The [Connect.js library](https://stripe.com/docs/connect/get-started-connect-embedded-components) and its supporting API allows you to add connected account dashboard functionality to your website.
 This NPM package contains initialization logic for Connect embedded components along with related types.
 
+Calling `loadConnect` always loads the latest version of Connect.js, regardless of which version of `@stripe/connect-js` you use. Updates for this package only impact tooling around the `loadConnect` helper itself and the TypeScript type definitions provided for Connect.js. Updates do not affect runtime availability of features of Connect.js.
+
 Note: Connect embedded components is currently still in beta. Please [contact us](https://stripe.com/docs/connect/get-started-connect-embedded-components#access) to request beta access.
 
 ## Installation


### PR DESCRIPTION
Summary & motivation
Adds a note on versioning of this library vs Connect.js to README preamble.

Testing & documentation
Tests N/A, this is a docs change only.

Similar to https://github.com/stripe/stripe-js/pull/473