### PR TITLE
Improve the error message for environments like nextjs

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -59,6 +59,12 @@ export const loadScript = (): Promise<StripeConnectWrapper | null> => {
   }
 
   stripePromise = new Promise((resolve, reject) => {
+    if (typeof window === "undefined") {
+      reject(
+        "ConnectJs won't load when rendering code in the server - it can only be loaded on a browser. This error is expected when loading ConnectJS in SSR environments, like NextJS. It will have no impact in the UI, however if you wish to avoid it, you can switch to the `pure` version of the connect.js loader: https://github.com/stripe/connect-js#importing-loadconnect-without-side-effects."
+      );
+    }
+
     if ((window as any).StripeConnect) {
       console.warn(EXISTING_SCRIPT_MESSAGE);
     }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -63,6 +63,7 @@ export const loadScript = (): Promise<StripeConnectWrapper | null> => {
       reject(
         "ConnectJs won't load when rendering code in the server - it can only be loaded on a browser. This error is expected when loading ConnectJS in SSR environments, like NextJS. It will have no impact in the UI, however if you wish to avoid it, you can switch to the `pure` version of the connect.js loader: https://github.com/stripe/connect-js#importing-loadconnect-without-side-effects."
       );
+      return;
     }
 
     if ((window as any).StripeConnect) {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -61,7 +61,7 @@ export const loadScript = (): Promise<StripeConnectWrapper | null> => {
   stripePromise = new Promise((resolve, reject) => {
     if (typeof window === "undefined") {
       reject(
-        "ConnectJs won't load when rendering code in the server - it can only be loaded on a browser. This error is expected when loading ConnectJS in SSR environments, like NextJS. It will have no impact in the UI, however if you wish to avoid it, you can switch to the `pure` version of the connect.js loader: https://github.com/stripe/connect-js#importing-loadconnect-without-side-effects."
+        "ConnectJS won't load when rendering code in the server - it can only be loaded on a browser. This error is expected when loading ConnectJS in SSR environments, like NextJS. It will have no impact in the UI, however if you wish to avoid it, you can switch to the `pure` version of the connect.js loader: https://github.com/stripe/connect-js#importing-loadconnect-without-side-effects."
       );
       return;
     }


### PR DESCRIPTION
Right now our error for when running connectjs in an SSR environment is:
```
ReferenceError: window is not defined
```

This PR improves the error, while it doesn't change the existing behavior (the promise is still rejecting).