### PR TITLE
Return the connect object from initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "1.0.10",
+  "version": "1.0.9",
   "description": "Connect.js loading utility package",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Connect.js loading utility package",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,7 +2,7 @@ import { version } from ".././package.json";
 import {
   StripeConnectWrapper,
   IStripeConnectInitParams,
-  ConnectElementTagName,
+  ConnectElementTagName
 } from "../types";
 
 export type LoadConnect = () => Promise<StripeConnectWrapper>;
@@ -20,7 +20,7 @@ const componentNameMapping: Record<
   payments: "stripe-connect-payments",
   payouts: "stripe-connect-payouts",
   "payment-details": "stripe-connect-payment-details",
-  "account-onboarding": "stripe-connect-account-onboarding",
+  "account-onboarding": "stripe-connect-account-onboarding"
 };
 
 const EXISTING_SCRIPT_MESSAGE =
@@ -118,9 +118,9 @@ const createWrapper = (stripeConnect: any) => {
           ...metaOptions,
           sdk: true,
           sdkOptions: {
-            sdkVersion: version,
-          },
-        },
+            sdkVersion: version
+          }
+        }
       }).connect;
 
       // We wrap create so we can map its different strings to supported components
@@ -135,7 +135,7 @@ const createWrapper = (stripeConnect: any) => {
         return oldCreate(htmlName);
       };
       return stripeConnectInstance;
-    },
+    }
   };
   return wrapper;
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -2,7 +2,7 @@ import { version } from ".././package.json";
 import {
   StripeConnectWrapper,
   IStripeConnectInitParams,
-  ConnectElementTagName
+  ConnectElementTagName,
 } from "../types";
 
 export type LoadConnect = () => Promise<StripeConnectWrapper>;
@@ -20,7 +20,7 @@ const componentNameMapping: Record<
   payments: "stripe-connect-payments",
   payouts: "stripe-connect-payouts",
   "payment-details": "stripe-connect-payment-details",
-  "account-onboarding": "stripe-connect-account-onboarding"
+  "account-onboarding": "stripe-connect-account-onboarding",
 };
 
 const EXISTING_SCRIPT_MESSAGE =
@@ -118,10 +118,10 @@ const createWrapper = (stripeConnect: any) => {
           ...metaOptions,
           sdk: true,
           sdkOptions: {
-            sdkVersion: version
-          }
-        }
-      });
+            sdkVersion: version,
+          },
+        },
+      }).connect;
 
       // We wrap create so we can map its different strings to supported components
       const oldCreate = stripeConnectInstance.create.bind(
@@ -135,7 +135,7 @@ const createWrapper = (stripeConnect: any) => {
         return oldCreate(htmlName);
       };
       return stripeConnectInstance;
-    }
+    },
   };
   return wrapper;
 };


### PR DESCRIPTION
stripeConnect.Init returns an object like {connect: connectInstance}. To simplify using methods (and to use `setReactSdkAnalytics`, I am returning the connect instance directly from init