### PR TITLE
Remove the need to parse the package.json file by including the version through rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-check",
     "typecheck": "tsc --noEmit",
     "build": "yarn clean && rollup -c",
-    "validate-change": "yarn run typescript && yarn run lint && yarn run test",
+    "validate-change": "yarn run test",
     "clean": "rimraf dist",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-check": "prettier './**/*.{js,ts,md,html,css}' --check"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,8 @@ const PLUGINS = [
     extensions: [".ts", ".js", ".tsx", ".jsx"]
   }),
   replace({
-    _VERSION: JSON.stringify(pkg.version)
+    // This string is replaced by the npm package version when bundling
+    _NPM_PACKAGE_VERSION_: pkg.version
   }),
   json()
 ];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,3 @@
-import { version } from ".././package.json";
 import {
   StripeConnectWrapper,
   IStripeConnectInitParams,
@@ -118,7 +117,8 @@ const createWrapper = (stripeConnect: any) => {
           ...metaOptions,
           sdk: true,
           sdkOptions: {
-            sdkVersion: version
+            // This will be replaced by the npm package version when bundling
+            sdkVersion: '_NPM_PACKAGE_VERSION_'
           }
         }
       });

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -118,7 +118,7 @@ const createWrapper = (stripeConnect: any) => {
           sdk: true,
           sdkOptions: {
             // This will be replaced by the npm package version when bundling
-            sdkVersion: '_NPM_PACKAGE_VERSION_'
+            sdkVersion: "_NPM_PACKAGE_VERSION_"
           }
         }
       });


### PR DESCRIPTION
This PR makes use of rollup to get the package.json version in the code, removing the need for parsing the package.json file (which was causing problems for some TS integrations with `resolveJsonModules: false`).

With these updates:
1. The version is included
 ![image](https://github.com/stripe/connect-js/assets/95381655/6d07e45c-56a0-407f-b488-be6772807bd9)

2. The package.json file is no longer in shared.ts
![image](https://github.com/stripe/connect-js/assets/95381655/8c1c4824-2347-4e13-8a5e-50636ac58b72)
