### PR TITLE
Remove the need to parse the package.json file by including the version through rollup (#49)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint '{src,types}/**/*.{ts,js}' && yarn prettier-check",
     "typecheck": "tsc --noEmit",
     "build": "yarn clean && rollup -c",
-    "validate-change": "yarn run typescript && yarn run lint && yarn run test",
+    "validate-change": "yarn run test",
     "clean": "rimraf dist",
     "prettier": "prettier './**/*.{js,ts,md,html,css}' --write",
     "prettier-check": "prettier './**/*.{js,ts,md,html,css}' --check"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,8 @@ const PLUGINS = [
     extensions: [".ts", ".js", ".tsx", ".jsx"]
   }),
   replace({
-    _VERSION: JSON.stringify(pkg.version)
+    // This string is replaced by the npm package version when bundling
+    _NPM_PACKAGE_VERSION_: pkg.version
   }),
   json()
 ];

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,3 @@
-import { version } from ".././package.json";
 import {
   StripeConnectWrapper,
   IStripeConnectInitParams,
@@ -125,7 +124,8 @@ const createWrapper = (stripeConnect: any) => {
           ...metaOptions,
           sdk: true,
           sdkOptions: {
-            sdkVersion: version
+            // This will be replaced by the npm package version when bundling
+            sdkVersion: "_NPM_PACKAGE_VERSION_"
           }
         }
       });


### PR DESCRIPTION
…

* Remove the need to parse the package.json file by including the version through rollup

* Prettier + package.json fix