### PR TITLE
Remove additional null typing and additional exports from package

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ import { loadConnect } from "@stripe/connect-js";
 const stripeConnect = await loadConnect();
 const connectInstance = stripeConnect.initialize({
   publishableKey: "{{pk test123}}",
-  clientSecret: "{{client secret}}",
+  clientSecret: "{{client secret}}"
 });
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { IStripeConnectInitParams, StripeConnectInstance } from "../types";
 import {
   loadScript,
   initStripeConnect,
-  LoadConnectAndInitialize,
+  LoadConnectAndInitialize
 } from "./shared";
 
 // Execute our own script injection after a tick to give users time to do their

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -16,7 +16,7 @@ describe("pure module", () => {
       publishableKey: "pk_123",
       fetchClientSecret: async () => {
         return "secret_123";
-      },
+      }
     };
     loadConnectAndInitialize(mockInitParams);
 

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -2,7 +2,7 @@ import { IStripeConnectInitParams, StripeConnectInstance } from "../types";
 import {
   loadScript,
   initStripeConnect,
-  LoadConnectAndInitialize,
+  LoadConnectAndInitialize
 } from "./shared";
 
 export const loadConnectAndInitialize: LoadConnectAndInitialize = (

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,7 +1,7 @@
 import {
   IStripeConnectInitParams,
   StripeConnectInstance,
-  ConnectElementTagName,
+  ConnectElementTagName
 } from "../types";
 
 export type LoadConnectAndInitialize = (
@@ -29,7 +29,7 @@ export const componentNameMapping: Record<
   "payment-method-settings": "stripe-connect-payment-method-settings",
   "account-management": "stripe-connect-account-management",
   "notification-banner": "stripe-connect-notification-banner",
-  "instant-payouts": "stripe-connect-instant-payouts",
+  "instant-payouts": "stripe-connect-instant-payouts"
 };
 
 type StripeConnectInstanceExtended = StripeConnectInstance & {
@@ -126,25 +126,25 @@ export const initStripeConnect = (
   stripePromise: Promise<StripeConnectWrapper>,
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
-  const stripeConnectInstance = stripePromise.then((wrapper) =>
+  const stripeConnectInstance = stripePromise.then(wrapper =>
     wrapper.initialize(initParams)
   );
 
   return {
-    create: (tagName) => {
+    create: tagName => {
       let htmlName = componentNameMapping[tagName];
       if (!htmlName) {
         htmlName = tagName as ConnectElementHTMLName;
       }
       const element = document.createElement(htmlName);
-      stripeConnectInstance.then((instance) => {
+      stripeConnectInstance.then(instance => {
         (element as any).setConnector((instance as any).connect);
       });
 
       return element;
     },
-    update: (updateOptions) => {
-      stripeConnectInstance.then((instance) => {
+    update: updateOptions => {
+      stripeConnectInstance.then(instance => {
         instance.update(updateOptions);
       });
     },
@@ -152,10 +152,10 @@ export const initStripeConnect = (
       return stripeConnectInstance;
     },
     logout: () => {
-      return stripeConnectInstance.then((instance) => {
+      return stripeConnectInstance.then(instance => {
         instance.logout();
       });
-    },
+    }
   };
 };
 
@@ -172,12 +172,12 @@ const createWrapper = (stripeConnect: any) => {
           sdk: true,
           sdkOptions: {
             // This will be replaced by the npm package version when bundling
-            sdkVersion: "_NPM_PACKAGE_VERSION_",
-          },
-        },
+            sdkVersion: "_NPM_PACKAGE_VERSION_"
+          }
+        }
       });
       return stripeConnectInstance;
-    },
+    }
   };
   return wrapper;
 };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -33,7 +33,7 @@ export const componentNameMapping: Record<
 };
 
 type StripeConnectInstanceExtended = StripeConnectInstance & {
-  debugInstance: () => Promise<StripeConnectInstance | undefined>;
+  debugInstance: () => Promise<StripeConnectInstance>;
 };
 
 interface StripeConnectWrapper {
@@ -44,7 +44,7 @@ const EXISTING_SCRIPT_MESSAGE =
   "loadConnect was called but an existing Connect.js script already exists in the document; existing script parameters will be used";
 const V0_URL = "https://connect-js.stripe.com/v0.1/connect.js";
 
-export const findScript = (): HTMLScriptElement | null => {
+export const findScript = (): HTMLScriptElement => {
   return document.querySelectorAll<HTMLScriptElement>(
     `script[src="${V0_URL}"]`
   )[0];
@@ -69,7 +69,7 @@ const injectScript = (): HTMLScriptElement => {
 
 let stripePromise: Promise<StripeConnectWrapper> | null = null;
 
-export const loadScript = (): Promise<StripeConnectWrapper | null> => {
+export const loadScript = (): Promise<StripeConnectWrapper> => {
   // Ensure that we only attempt to load Connect.js at most once
   if (stripePromise !== null) {
     return stripePromise;
@@ -123,12 +123,13 @@ export const loadScript = (): Promise<StripeConnectWrapper | null> => {
 };
 
 export const initStripeConnect = (
-  stripePromise: Promise<StripeConnectWrapper | null>,
+  stripePromise: Promise<StripeConnectWrapper>,
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
   const stripeConnectInstance = stripePromise.then((wrapper) =>
-    wrapper?.initialize(initParams)
+    wrapper.initialize(initParams)
   );
+
   return {
     create: (tagName) => {
       let htmlName = componentNameMapping[tagName];
@@ -144,7 +145,7 @@ export const initStripeConnect = (
     },
     update: (updateOptions) => {
       stripeConnectInstance.then((instance) => {
-        instance?.update(updateOptions);
+        instance.update(updateOptions);
       });
     },
     debugInstance: () => {
@@ -152,7 +153,7 @@ export const initStripeConnect = (
     },
     logout: () => {
       return stripeConnectInstance.then((instance) => {
-        instance?.logout();
+        instance.logout();
       });
     },
   };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -44,7 +44,7 @@ const EXISTING_SCRIPT_MESSAGE =
   "loadConnect was called but an existing Connect.js script already exists in the document; existing script parameters will be used";
 const V0_URL = "https://connect-js.stripe.com/v0.1/connect.js";
 
-export const findScript = (): HTMLScriptElement => {
+export const findScript = (): HTMLScriptElement | null => {
   return document.querySelectorAll<HTMLScriptElement>(
     `script[src="${V0_URL}"]`
   )[0];
@@ -75,7 +75,7 @@ export const loadScript = (): Promise<StripeConnectWrapper> => {
     return stripePromise;
   }
 
-  stripePromise = new Promise((resolve, reject) => {
+  stripePromise = new Promise<StripeConnectWrapper>((resolve, reject) => {
     if (typeof window === "undefined") {
       reject(
         "ConnectJS won't load when rendering code in the server - it can only be loaded on a browser. This error is expected when loading ConnectJS in SSR environments, like NextJS. It will have no impact in the UI, however if you wish to avoid it, you can switch to the `pure` version of the connect.js loader: https://github.com/stripe/connect-js#importing-loadconnect-without-side-effects."

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -380,7 +380,7 @@ export interface StripeConnectInstance {
    * @tagName Name of the Connect component to create.
    * @returns An HTML component corresponding to that connect component
    */
-  create: (tagName: ConnectElementTagName) => HTMLElement | null;
+  create: (tagName: ConnectElementTagName) => HTMLElement;
 
   /**
    * Updates the Connect instance with new parameters.
@@ -407,7 +407,3 @@ export type ConnectElementTagName =
   | "account-management"
   | "notification-banner"
   | "instant-payouts";
-
-export declare const findScript: () => HTMLScriptElement | null;
-
-export declare const loadScript: () => Promise<any | null>;


### PR DESCRIPTION
We had `loadScript` and `findScript`. These are no longer needed.

Additionally I removed some `| null` and `| undefined` blocks we had