### PR TITLE
fix custom method unavailability issue during connect instance loading

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -155,7 +155,6 @@ export const initStripeConnect = (
         for (const method in methods) {
           (element as any)[method] = function(value: any) {
             stripeConnectInstance.then(() => {
-              console.log((element as any)[`${method}InternalOnly`]);
               this[`${method}InternalOnly`](value);
             });
           };

--- a/types/config.ts
+++ b/types/config.ts
@@ -1,26 +1,31 @@
-import {ConnectElementTagName} from './shared.d';
+import { ConnectElementTagName } from "./shared.d";
 
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export const ConnectElementCustomMethodConfig = {
-    "payment-details": {
-        setPayment: (payment: string | undefined): void => {},
-        setOnClose: (listener: (() => void) | undefined): void => {},
-    },
-    "account-onboarding": {
-        setFullTermsOfServiceUrl: (termOfServiceUrl: string | undefined): void => {},
-        setRecipientTermsOfServiceUrl: (
-            recipientTermsOfServiceUrl: string | undefined
-        ): void => {},
-        setPrivacyPolicyUrl: (privacyPolicyUrl: string | undefined): void => {},
-        setSkipTermsOfServiceCollection: (
-        skipTermsOfServiceCollection: boolean | undefined
-        ): void => {},
-        setOnExit: (listener: (() => void) | undefined): void => {},
-    }
+  "payment-details": {
+    setPayment: (payment: string | undefined): void => {},
+    setOnClose: (listener: (() => void) | undefined): void => {}
+  },
+  "account-onboarding": {
+    setFullTermsOfServiceUrl: (
+      termOfServiceUrl: string | undefined
+    ): void => {},
+    setRecipientTermsOfServiceUrl: (
+      recipientTermsOfServiceUrl: string | undefined
+    ): void => {},
+    setPrivacyPolicyUrl: (privacyPolicyUrl: string | undefined): void => {},
+    setSkipTermsOfServiceCollection: (
+      skipTermsOfServiceCollection: boolean | undefined
+    ): void => {},
+    setOnExit: (listener: (() => void) | undefined): void => {}
+  }
 };
 
 // ensure that keys of ConnectElementCustomMethodConfig are from ConnectElementTagName
 type HasType<T, Q extends T> = Q;
-type CustomMethodConfigValidation = HasType<ConnectElementTagName, keyof typeof ConnectElementCustomMethodConfig>;
+type CustomMethodConfigValidation = HasType<
+  ConnectElementTagName,
+  keyof typeof ConnectElementCustomMethodConfig
+>;

--- a/types/config.ts
+++ b/types/config.ts
@@ -1,0 +1,26 @@
+import {ConnectElementTagName} from './shared.d';
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export const ConnectElementCustomMethodConfig = {
+    "payment-details": {
+        setPayment: (payment: string | undefined): void => {},
+        setOnClose: (listener: (() => void) | undefined): void => {},
+    },
+    "account-onboarding": {
+        setFullTermsOfServiceUrl: (termOfServiceUrl: string | undefined): void => {},
+        setRecipientTermsOfServiceUrl: (
+            recipientTermsOfServiceUrl: string | undefined
+        ): void => {},
+        setPrivacyPolicyUrl: (privacyPolicyUrl: string | undefined): void => {},
+        setSkipTermsOfServiceCollection: (
+        skipTermsOfServiceCollection: boolean | undefined
+        ): void => {},
+        setOnExit: (listener: (() => void) | undefined): void => {},
+    }
+};
+
+// ensure that keys of ConnectElementCustomMethodConfig are from ConnectElementTagName
+type HasType<T, Q extends T> = Q;
+type CustomMethodConfigValidation = HasType<ConnectElementTagName, keyof typeof ConnectElementCustomMethodConfig>;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,4 +1,4 @@
-import {ConnectElementCustomMethodConfig} from './config';
+import { ConnectElementCustomMethodConfig } from "./config";
 
 export declare type LoadConnectAndInitialize = (
   initParams: IStripeConnectInitParams
@@ -379,10 +379,12 @@ export interface IStripeConnectInitParams {
 type ConnectElementCustomMethods = typeof ConnectElementCustomMethodConfig;
 
 type ConnectHTMLElementRecordBase = {
-  [K in keyof ConnectElementCustomMethods]: HTMLElement & ConnectElementCustomMethods[K];
-} & {
-  [tagName in ConnectElementTagName]: HTMLElement;
-};
+  [K in keyof ConnectElementCustomMethods]: HTMLElement &
+    ConnectElementCustomMethods[K];
+} &
+  {
+    [tagName in ConnectElementTagName]: HTMLElement;
+  };
 
 interface ConnectHTMLElementRecord extends ConnectHTMLElementRecordBase {
   [key: string]: HTMLElement | null;

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,3 +1,5 @@
+import {ConnectElementCustomMethodConfig} from './config';
+
 export declare type LoadConnectAndInitialize = (
   initParams: IStripeConnectInitParams
 ) => StripeConnectInstance;
@@ -374,31 +376,16 @@ export interface IStripeConnectInitParams {
   locale?: string;
 }
 
-type ConnectHTMLElementRecordFallback = {
-  [key in string]: HTMLElement | null;
-};
+type ConnectElementCustomMethods = typeof ConnectElementCustomMethodConfig;
+
 type ConnectHTMLElementRecordBase = {
+  [K in keyof ConnectElementCustomMethods]: HTMLElement & ConnectElementCustomMethods[K];
+} & {
   [tagName in ConnectElementTagName]: HTMLElement;
 };
 
-interface ConnectHTMLElementRecord
-  extends ConnectHTMLElementRecordBase,
-    ConnectHTMLElementRecordFallback {
-  "payment-details": HTMLElement & {
-    setPayment: (payment: string | undefined) => void;
-    setOnClose: (listener: (() => void) | undefined) => void;
-  };
-  "account-onboarding": HTMLElement & {
-    setFullTermsOfServiceUrl: (termOfServiceUrl: string | undefined) => void;
-    setRecipientTermsOfServiceUrl: (
-      recipientTermsOfServiceUrl: string | undefined
-    ) => void;
-    setPrivacyPolicyUrl: (privacyPolicyUrl: string | undefined) => void;
-    setSkipTermsOfServiceCollection: (
-      skipTermsOfServiceCollection: boolean | undefined
-    ) => void;
-    setOnExit: (listener: (() => void) | undefined) => void;
-  };
+interface ConnectHTMLElementRecord extends ConnectHTMLElementRecordBase {
+  [key: string]: HTMLElement | null;
 }
 
 export interface StripeConnectInstance {

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -378,17 +378,13 @@ export interface IStripeConnectInitParams {
 
 type ConnectElementCustomMethods = typeof ConnectElementCustomMethodConfig;
 
-type ConnectHTMLElementRecordBase = {
+type ConnectHTMLElementRecord = {
   [K in keyof ConnectElementCustomMethods]: HTMLElement &
     ConnectElementCustomMethods[K];
 } &
   {
-    [tagName in ConnectElementTagName]: HTMLElement;
+    [key: string]: HTMLElement;
   };
-
-interface ConnectHTMLElementRecord extends ConnectHTMLElementRecordBase {
-  [key: string]: HTMLElement | null;
-}
 
 export interface StripeConnectInstance {
   /**


### PR DESCRIPTION
When initialize, inject to the connect element the custom setter methods that asynchronously calls internal custom setter methods when the connect instance resolves.