### PR TITLE
Make typescript compilation more strict + fix type issues

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -51,9 +51,11 @@ const EXISTING_SCRIPT_MESSAGE =
 const V0_URL = "https://connect-js.stripe.com/v0.1/connect.js";
 
 export const findScript = (): HTMLScriptElement | null => {
-  return document.querySelectorAll<HTMLScriptElement>(
-    `script[src="${V0_URL}"]`
-  )[0];
+  return (
+    document.querySelectorAll<HTMLScriptElement>(
+      `script[src="${V0_URL}"]`
+    )[0] || null
+  );
 };
 
 const injectScript = (): HTMLScriptElement => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
 
-    // Turn off strict compilation flags
+    // Turn on additional typechecking flags
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,19 @@
     "removeComments": false,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+
+    // Turn off strict compilation flags
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "noImplicitAny": true,
+    "noFallthroughCasesInSwitch": true,
+    "exactOptionalPropertyTypes": true,
   },
   "include": ["src", "types/index.d.ts", "types/shared.d.ts"]
 }

--- a/types/checks.ts
+++ b/types/checks.ts
@@ -1,0 +1,9 @@
+import { ConnectElementCustomMethodConfig } from "./config";
+import { ConnectElementTagName } from "./shared.d";
+
+// ensure that keys of ConnectElementCustomMethodConfig are from ConnectElementTagName
+export type HasType<T, Q extends T> = Q;
+export type CustomMethodConfigValidation = HasType<
+  ConnectElementTagName,
+  keyof typeof ConnectElementCustomMethodConfig
+>;

--- a/types/config.ts
+++ b/types/config.ts
@@ -1,39 +1,30 @@
-import { ConnectElementTagName } from "./shared.d";
-
 /* eslint-disable @typescript-eslint/no-empty-function */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export const ConnectElementCustomMethodConfig = {
   "payment-details": {
-    setPayment: (payment: string | undefined): void => {},
-    setOnClose: (listener: (() => void) | undefined): void => {}
+    setPayment: (_payment: string | undefined): void => {},
+    setOnClose: (_listener: (() => void) | undefined): void => {}
   },
   "account-onboarding": {
     setFullTermsOfServiceUrl: (
-      termOfServiceUrl: string | undefined
+      _termOfServiceUrl: string | undefined
     ): void => {},
     setRecipientTermsOfServiceUrl: (
-      recipientTermsOfServiceUrl: string | undefined
+      _recipientTermsOfServiceUrl: string | undefined
     ): void => {},
-    setPrivacyPolicyUrl: (privacyPolicyUrl: string | undefined): void => {},
+    setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
     setSkipTermsOfServiceCollection: (
-      skipTermsOfServiceCollection: boolean | undefined
+      _skipTermsOfServiceCollection: boolean | undefined
     ): void => {},
-    setOnExit: (listener: (() => void) | undefined): void => {}
+    setOnExit: (_listener: (() => void) | undefined): void => {}
   },
   "issuing-card": {
-    setDefaultCard: (defaultCard: string | undefined): void => {},
-    setCardArtFileLink: (cardArtFileLink: string | undefined): void => {},
-    setCardSwitching: (cardSwitching: boolean | undefined): void => {}
+    setDefaultCard: (_defaultCard: string | undefined): void => {},
+    setCardArtFileLink: (_cardArtFileLink: string | undefined): void => {},
+    setCardSwitching: (_cardSwitching: boolean | undefined): void => {}
   },
   "issuing-cards-list": {
-    setCardArtFileLink: (cardArtFileLink: string | undefined): void => {}
+    setCardArtFileLink: (_cardArtFileLink: string | undefined): void => {}
   }
 };
-
-// ensure that keys of ConnectElementCustomMethodConfig are from ConnectElementTagName
-type HasType<T, Q extends T> = Q;
-type CustomMethodConfigValidation = HasType<
-  ConnectElementTagName,
-  keyof typeof ConnectElementCustomMethodConfig
->;


### PR DESCRIPTION
Fixes https://github.com/stripe/connect-js/issues/83 by adding more compilation validation flags and addressing the failures that came from enabling those.