### PR TITLE
Improve the error that happens when you use an unsupported component

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -178,6 +178,12 @@ export const initStripeConnect = (
           element.style.display = oldDisplay;
         }
 
+        if (!element || !(element as any).setConnector) {
+          throw new Error(
+            `Element ${tagName} was not transformed into a custom element. Are you using a documented component? See https://docs.stripe.com/connect/supported-embedded-components for a list of supported components`
+          );
+        }
+
         (element as any).setConnector((instance as any).connect);
       });
 


### PR DESCRIPTION
Errors like https://github.com/stripe/connect-js/issues/116 are hard to debug. This PR makes it easier by providing a specific error.