### PR TITLE
[Beta] Add balances, payouts-list, app-install, app-viewport

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -26,7 +26,11 @@ export type ConnectElementHTMLName =
   | "stripe-connect-capital-overview"
   | "stripe-connect-documents"
   | "stripe-connect-tax-registrations"
-  | "stripe-connect-tax-settings";
+  | "stripe-connect-tax-settings"
+  | "stripe-connect-balances"
+  | "stripe-connect-payouts-list"
+  | "stripe-connect-app-install"
+  | "stripe-connect-app-viewport";
 
 export const componentNameMapping: Record<
   ConnectElementTagName,
@@ -48,7 +52,11 @@ export const componentNameMapping: Record<
   "capital-overview": "stripe-connect-capital-overview",
   documents: "stripe-connect-documents",
   "tax-registrations": "stripe-connect-tax-registrations",
-  "tax-settings": "stripe-connect-tax-settings"
+  "tax-settings": "stripe-connect-tax-settings",
+  "balances": "stripe-connect-balances",
+  "payouts-list": "stripe-connect-payouts-list",
+  "app-install": "stripe-connect-app-install",
+  "app-viewport": "stripe-connect-app-viewport"
 };
 
 type StripeConnectInstanceExtended = StripeConnectInstance & {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -53,7 +53,7 @@ export const componentNameMapping: Record<
   documents: "stripe-connect-documents",
   "tax-registrations": "stripe-connect-tax-registrations",
   "tax-settings": "stripe-connect-tax-settings",
-  "balances": "stripe-connect-balances",
+  balances: "stripe-connect-balances",
   "payouts-list": "stripe-connect-payouts-list",
   "app-install": "stripe-connect-app-install",
   "app-viewport": "stripe-connect-app-viewport"

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -462,4 +462,8 @@ export type ConnectElementTagName =
   | "capital-overview"
   | "documents"
   | "tax-registrations"
-  | "tax-settings";
+  | "tax-settings"
+  | "balances"
+  | "payouts-list"
+  | "app-install"
+  | "app-viewport";


### PR DESCRIPTION
Adds the following components to beta version of connect-js:
- balances (is GA, but was missed in the beta branch)
- payouts-list (is GA, but was missed in the beta branch)
- app-install
- app-viewport