### PR TITLE
eager fetch client secret

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -139,21 +139,11 @@ export const initStripeConnect = (
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
   const clientSecretPromise = initParams.fetchClientSecret();
-  let cachedClientSecretUsed = false;
-
-  const fetchClientSecret = async () => {
-    if (!cachedClientSecretUsed) {
-      cachedClientSecretUsed = true;
-      return await clientSecretPromise;
-    } else {
-      return await initParams.fetchClientSecret();
-    }
-  };
   const stripeConnectInstance = stripePromise.then(wrapper =>
     wrapper.initialize({
       ...initParams,
-      fetchClientSecret
-    })
+      clientSecretPromise
+    } as any)
   );
 
   return {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -138,11 +138,18 @@ export const initStripeConnect = (
   stripePromise: Promise<StripeConnectWrapper>,
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
-  const clientSecretPromise = initParams.fetchClientSecret();
+  const clientSecretPromise = (() => {
+    try {
+      return initParams.fetchClientSecret();
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  })();
+  const metaOptions = (initParams as any).metaOptions ?? {};
   const stripeConnectInstance = stripePromise.then(wrapper =>
     wrapper.initialize({
       ...initParams,
-      clientSecretPromise
+      metaOptions: { ...metaOptions, clientSecretPromise }
     } as any)
   );
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -138,8 +138,22 @@ export const initStripeConnect = (
   stripePromise: Promise<StripeConnectWrapper>,
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
+  const clientSecretPromise = initParams.fetchClientSecret();
+  let cachedClientSecretUsed = false;
+
+  const fetchClientSecret = async () => {
+    if (!cachedClientSecretUsed) {
+      cachedClientSecretUsed = true;
+      return await clientSecretPromise;
+    } else {
+      return await initParams.fetchClientSecret();
+    }
+  };
   const stripeConnectInstance = stripePromise.then(wrapper =>
-    wrapper.initialize(initParams)
+    wrapper.initialize({
+      ...initParams,
+      fetchClientSecret
+    })
   );
 
   return {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -138,7 +138,7 @@ export const initStripeConnect = (
   stripePromise: Promise<StripeConnectWrapper>,
   initParams: IStripeConnectInitParams
 ): StripeConnectInstanceExtended => {
-  const clientSecretPromise = (() => {
+  const eagerClientSecretPromise = (() => {
     try {
       return initParams.fetchClientSecret();
     } catch (error) {
@@ -149,7 +149,7 @@ export const initStripeConnect = (
   const stripeConnectInstance = stripePromise.then(wrapper =>
     wrapper.initialize({
       ...initParams,
-      metaOptions: { ...metaOptions, clientSecretPromise }
+      metaOptions: { ...metaOptions, eagerClientSecretPromise }
     } as any)
   );
 


### PR DESCRIPTION
Start fetching client secret without waiting on stripePromise, so that fetch client secret can go parallel with loading connect.js.

The eager fetching only applies for the first time of fetching client secret, or else when we attempt to refresh client secret, the returned secret could be stale.

|before|after|
|--|--|
|![Screenshot 2024-06-19 at 11 47 44 PM](https://github.com/stripe/connect-js/assets/110323300/42a266c0-3758-43a3-8054-1d0e313dc4cb)|![Screenshot 2024-06-19 at 11 42 39 PM](https://github.com/stripe/connect-js/assets/110323300/6b87cd74-0037-430f-9629-911f7c142038)|