### PR TITLE
add nullcheck initParams

### DIFF
--- a/src/pure.ts
+++ b/src/pure.ts
@@ -9,5 +9,10 @@ export const loadConnectAndInitialize: LoadConnectAndInitialize = (
   initParams: IStripeConnectInitParams
 ): StripeConnectInstance => {
   const maybeConnect = loadScript();
+  if (initParams == null) {
+    throw new Error(
+      "You must provide required parameters to initialize Connect"
+    );
+  }
   return initStripeConnect(maybeConnect, initParams);
 };


### PR DESCRIPTION
beta version of https://github.com/stripe/connect-js/pull/130
add nullcheck to initParams to throw if it's undefined or null, as some platforms might not use typescript.