### PR TITLE
Added strict type imports for shared types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { IStripeConnectInitParams, StripeConnectInstance } from "../types";
+import type { IStripeConnectInitParams, StripeConnectInstance } from "../types";
 import {
   loadScript,
   initStripeConnect,

--- a/src/pure.test.ts
+++ b/src/pure.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-import { IStripeConnectInitParams } from "../types";
+import type { IStripeConnectInitParams } from "../types";
 import { SCRIPT_SELECTOR } from "./utils/jestHelpers";
 
 describe("pure module", () => {

--- a/src/pure.ts
+++ b/src/pure.ts
@@ -1,4 +1,4 @@
-import { IStripeConnectInitParams, StripeConnectInstance } from "../types";
+import type { IStripeConnectInitParams, StripeConnectInstance } from "../types";
 import {
   loadScript,
   initStripeConnect,

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IStripeConnectInitParams,
   StripeConnectInstance,
   ConnectElementTagName,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import { IStripeConnectInitParams, StripeConnectInstance } from "../types";
+import type { IStripeConnectInitParams, StripeConnectInstance } from "../types";
 
 export declare const loadConnectAndInitialize: (
   initParams: IStripeConnectInitParams


### PR DESCRIPTION
In our project we have `verbatimModuleSyntax` enabled which causes issues with `connect-js` type imports. The error we get are as follows

apps/app-shell type-check$ tsc --noEmit --incremental false
apps/app-shell type-check: ../../node_modules/.pnpm/@stripe+connect-js@3.3.10/node_modules/@stripe/connect-js/src/shared.ts(2,3): error TS1484: 'IStripeConnectInitParams' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
apps/app-shell type-check: ../../node_modules/.pnpm/@stripe+connect-js@3.3.10/node_modules/@stripe/connect-js/src/shared.ts(3,3): error TS1484: 'StripeConnectInstance' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
apps/app-shell type-check: ../../node_modules/.pnpm/@stripe+connect-js@3.3.10/node_modules/@stripe/connect-js/src/shared.ts(4,3): error TS1484: 'ConnectElementTagName' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.
apps/app-shell type-check: ../../node_modules/.pnpm/@stripe+connect-js@3.3.10/node_modules/@stripe/connect-js/src/shared.ts(5,3): error TS1484: 'ConnectHTMLElementRecord' is a type and must be imported using a type-only import when 'verbatimModuleSyntax' is enabled.

I believe the following update shouldn't cause any issues and should be able to fix the issues that we are having as well