### PR TITLE
Add config setter to the payment-method-settings component

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -142,5 +142,10 @@ export const ConnectElementCustomMethodConfig = {
   "app-viewport": {
     setApp: (_app: string | undefined): void => {},
     setAppData: (_appData: Record<string, string> | undefined): void => {}
+  },
+  "payment-method-settings": {
+    setPaymentMethodConfiguration: (
+      _paymentMethodConfiguration: string | undefined
+    ): void => {}
   }
 };


### PR DESCRIPTION
I'm adding the payment method configuration attribute to the `payment-method-settings` component that is currently in beta.

Next up: bumping the connect-js package version in react-connect-js and adding the React prop: https://github.com/stripe/react-connect-js/pull/106. I've validated both PRs against a local instance of Furever using yalc.