### PR TITLE
Remove card art file link setter from Issuing embedded components

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -112,14 +112,12 @@ export const ConnectElementCustomMethodConfig = {
   },
   "issuing-card": {
     setDefaultCard: (_defaultCard: string | undefined): void => {},
-    setCardArtFileLink: (_cardArtFileLink: string | undefined): void => {},
     setCardSwitching: (_cardSwitching: boolean | undefined): void => {},
     setFetchEphemeralKey: (
       _fetchEphemeralKey: FetchEphemeralKeyFunction | undefined
     ): void => {}
   },
   "issuing-cards-list": {
-    setCardArtFileLink: (_cardArtFileLink: string | undefined): void => {},
     setFetchEphemeralKey: (
       _fetchEphemeralKey: FetchEphemeralKeyFunction | undefined
     ): void => {}


### PR DESCRIPTION
We'll be removing the card art file link setter from the Issuing embedded components, so we need to remove it from this SDK first.