### PR TITLE
Add show spend controls setter to Issuing embedded components

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -128,12 +128,14 @@ export const ConnectElementCustomMethodConfig = {
     setCardSwitching: (_cardSwitching: boolean | undefined): void => {},
     setFetchEphemeralKey: (
       _fetchEphemeralKey: FetchEphemeralKeyFunction | undefined
-    ): void => {}
+    ): void => {},
+    setShowSpendControls: (_showSpendControls: boolean | undefined): void => {}
   },
   "issuing-cards-list": {
     setFetchEphemeralKey: (
       _fetchEphemeralKey: FetchEphemeralKeyFunction | undefined
-    ): void => {}
+    ): void => {},
+    setShowSpendControls: (_showSpendControls: boolean | undefined): void => {}
   },
   "financial-account": {
     setFinancialAccount: (_financialAccount: string): void => {}


### PR DESCRIPTION
We added a show-spend-controls attribute to the Issuing embedded components per https://docs.google.com/document/d/1qcbH2_ODEJK56Age6qSdoQoBld3OdgVTGkYbVOlJAuM/edit?pli=1#heading=h.73olkzk9kr53. We need to add it to connect-js too.