### PR TITLE
Add link customization HTML params for Capital application and promo components

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -175,7 +175,9 @@ export const ConnectElementCustomMethodConfig = {
     ): void => {}
   },
   "capital-financing-application": {
-    setOnApplicationSubmitted: (_listener: (() => void) | undefined): void => {}
+    setOnApplicationSubmitted: (_listener: (() => void) | undefined): void => {},
+    setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
+    setHowCapitalWorksUrl: (_howCapitalWorksUrl: string | undefined): void => {}
   },
   "capital-financing-promotion": {
     setLayout: (_layout: FinancingPromotionLayoutType | undefined): void => {},
@@ -184,6 +186,9 @@ export const ConnectElementCustomMethodConfig = {
     ): void => {},
     setOnEligibleFinancingOfferLoaded: (
       _listener: (({ productType }: FinancingProductType) => void) | undefined
-    ): void => {}
+    ): void => {},
+    setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
+    setHowCapitalWorksUrl: (_howCapitalWorksUrl: string | undefined): void => {},
+    setEligibilityCriteriaUrl: (_eligibilityCriteriaUrl: string | undefined): void => {}
   }
 };

--- a/types/config.ts
+++ b/types/config.ts
@@ -175,7 +175,9 @@ export const ConnectElementCustomMethodConfig = {
     ): void => {}
   },
   "capital-financing-application": {
-    setOnApplicationSubmitted: (_listener: (() => void) | undefined): void => {},
+    setOnApplicationSubmitted: (
+      _listener: (() => void) | undefined
+    ): void => {},
     setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
     setHowCapitalWorksUrl: (_howCapitalWorksUrl: string | undefined): void => {}
   },
@@ -188,7 +190,11 @@ export const ConnectElementCustomMethodConfig = {
       _listener: (({ productType }: FinancingProductType) => void) | undefined
     ): void => {},
     setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
-    setHowCapitalWorksUrl: (_howCapitalWorksUrl: string | undefined): void => {},
-    setEligibilityCriteriaUrl: (_eligibilityCriteriaUrl: string | undefined): void => {}
+    setHowCapitalWorksUrl: (
+      _howCapitalWorksUrl: string | undefined
+    ): void => {},
+    setEligibilityCriteriaUrl: (
+      _eligibilityCriteriaUrl: string | undefined
+    ): void => {}
   }
 };


### PR DESCRIPTION
Add new html params for `capital-financing-application` and `capital-financing-promotion` components per the updated [API Review Addendum](https://docs.google.com/document/d/1UOfEiV031A8ml3dJJNaHjdZs3PAMp0B0zCmgj4Hk2P0/edit#bookmark=id.blg5ihxorla3)

- Promotion component
  - `privacyPolicyUrl`
  - `eligibilityCriteriaUrl`
  - `howCapitalWorksUrl`
- Application component
  - `privacyPolicyUrl`
  - `howCapitalWorksUrl`