### PR TITLE
Rename CapitalFinancing faqUrl parameter

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -178,7 +178,9 @@ export const ConnectElementCustomMethodConfig = {
     setShowFinancingSelector: (
       _showFinancingSelector: boolean | undefined
     ): void => {},
-    setFaqUrl: (_faqUrl: string | undefined): void => {},
+    setHowCapitalWorksUrl: (
+      _howCapitalWorksUrl: string | undefined
+    ): void => {},
     setSupportUrl: (_supportUrl: string | undefined): void => {},
     setOnFinancingsLoaded: (
       _listener: (({ total }: { total: number }) => void) | undefined


### PR DESCRIPTION
Renames the `faqUrl` parameter to `howCapitalWorksUrl` to be consistent with the other Capital components per the latest [API review addendum](https://docs.google.com/document/d/1UOfEiV031A8ml3dJJNaHjdZs3PAMp0B0zCmgj4Hk2P0/edit?tab=t.0#bookmark=id.bwp66tafe1n3)

Note that this is a _breaking_ change but the component is not used by any external platforms