### PR TITLE
add new appearance options

### DIFF
--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -151,9 +151,41 @@ export declare type AppearanceVariables = {
    */
   actionPrimaryColorText?: string;
   /**
+   * The line type used for text decoration of primary actions and links. This accepts a valid text decoration line value.
+   */
+  actionPrimaryTextDecorationLine?: string;
+  /**
+   * The color used for text decoration of primary actions and links. This accepts hex values or RGB/HSL strings.
+   */
+  actionPrimaryTextDecorationColor?: string;
+  /**
+   * The style of text decoration of primary actions and links. This accepts a valid text decoration style value.
+   */
+  actionPrimaryTextDecorationStyle?: string;
+  /**
+   * The thickness of text decoration of primary actions and links. This accepts a valid text decoration thickness value.
+   */
+  actionPrimaryTextDecorationThickness?: string;
+  /**
    * The color used for secondary actions and links. This accepts hex values or RGB/HSL strings.
    */
   actionSecondaryColorText?: string;
+  /**
+   * The line type used for text decoration of secondary actions and links. This accepts a valid text decoration line value.
+   */
+  actionSecondaryTextDecorationLine?: string;
+  /**
+   * The color used for text decoration of secondary actions and links. This accepts hex values or RGB/HSL strings.
+   */
+  actionSecondaryTextDecorationColor?: string;
+  /**
+   * The style of text decoration of secondary actions and links. This accepts a valid text decoration style value.
+   */
+  actionSecondaryTextDecorationStyle?: string;
+  /**
+   * The thickness of text decoration of secondary actions and links. This accepts a valid text decoration thickness value.
+   */
+  actionSecondaryTextDecorationThickness?: string;
 
   // Neutral Badge Colors
   /**
@@ -261,6 +293,10 @@ export declare type AppearanceVariables = {
    * A z-index to use for the overlay throughout embedded components. Set this number to control the z-order of the overlay.
    */
   overlayZIndex?: number;
+  /**
+   * The backdrop color when an overlay is opened. This accepts hex values or RGB/RGBA/HSL strings.
+   */
+  overlayBackdropColor?: string;
 
   // Body Typography
   /**


### PR DESCRIPTION
Add the new appearance options to connect-js now that they're supported.
Tested changing the options (with the SDK) with connect-test:

<img width="545" alt="Screenshot 2024-10-10 at 3 42 32 PM" src="https://github.com/user-attachments/assets/0fc4d4f6-8adc-43d6-823b-1dc1b923ccc1">
<img width="475" alt="Screenshot 2024-10-10 at 3 42 56 PM" src="https://github.com/user-attachments/assets/5c57cd35-9f64-4de5-b5c2-34b93ba208fc">
