### PR TITLE
Add tax types for additional properties to the preview branch

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -214,5 +214,20 @@ export const ConnectElementCustomMethodConfig = {
     setIntervalStart: (_intervalStart: Date | undefined): void => {},
     setIntervalEnd: (_intervalEnd: Date | undefined): void => {},
     setIntervalType: (_intervalType: IntervalType | undefined): void => {}
+  },
+  "tax-settings": {
+    setHideProductTaxCodeSelector: (_hidden: boolean | undefined): void => {},
+    setDisplayHeadOfficeCountries: (
+      _countries: string[] | undefined
+    ): void => {},
+    setOnTaxSettingsUpdated: (
+      _listener: (({ id }: { id: string }) => void) | undefined
+    ): void => {}
+  },
+  "tax-registrations": {
+    setOnAfterTaxRegistrationAdded: (
+      _listener: (({ id }: { id: string }) => void) | undefined
+    ): void => {},
+    setDisplayCountries: (_countries: string[] | undefined): void => {}
   }
 };


### PR DESCRIPTION
We added the props to the main branch but we should also add them to the preview branch because a platform that wants to use the feature is still using the preview branch.

Overall, is there any process that your team is merging the `master` branch periodically into the `preview` branch?