### PR TITLE
Add activeFinancingCount to setOnEligibleFinancingOfferLoaded payload in CapitalFinancingPromotion component

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -322,7 +322,7 @@ export const ConnectElementCustomMethodConfig = {
       _listener:
         | (({
             productType,
-            activeFinancingCount,
+            activeFinancingCount
           }: FinancingProductType) => void)
         | undefined
     ): void => {},

--- a/types/config.ts
+++ b/types/config.ts
@@ -159,6 +159,7 @@ export type EmbeddedError = {
 
 export type FinancingProductType = {
   productType: "standard" | "refill" | "none";
+  activeFinancingCount: number;
 };
 
 export type FinancingPromotionLayoutType = "full" | "banner";
@@ -318,7 +319,12 @@ export const ConnectElementCustomMethodConfig = {
       _listener: (() => void) | undefined
     ): void => {},
     setOnEligibleFinancingOfferLoaded: (
-      _listener: (({ productType }: FinancingProductType) => void) | undefined
+      _listener:
+        | (({
+            productType,
+            activeFinancingCount,
+          }: FinancingProductType) => void)
+        | undefined
     ): void => {},
     setPrivacyPolicyUrl: (_privacyPolicyUrl: string | undefined): void => {},
     setHowCapitalWorksUrl: (


### PR DESCRIPTION
Adds a new field, `activeFinancingCount` to the data payload for the `setOnEligibleFinancingOfferLoaded` in the CapitalFinancingPromotion component so that platforms are able to selectively hide the component if the connected account has active financing.