### PR TITLE
Prevent errors when using `verbatimModuleSyntax`

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   IStripeConnectInitParams,
   StripeConnectInstance,
   ConnectElementTagName,


### PR DESCRIPTION
Tiny, one-line change to fix the following errors when this lib is used via the `/pure` import path and `verbatimModuleSyntax` is enabled in `tsconfig.json`:

<img width="1092" alt="image" src="https://github.com/user-attachments/assets/89123148-fb86-4f3c-a6a6-36c641673b95" />
