### PR TITLE
Fix incorrect type definition for setOnTaxCodeSelect setter

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -368,7 +368,7 @@ export const ConnectElementCustomMethodConfig = {
   },
   "product-tax-code-selector": {
     setOnTaxCodeSelect: (
-      _listener: (({ taxCode }: { taxCode: string }) => void) | undefined
+      _listener: ((taxCode: string) => void) | undefined
     ): void => {},
     setHideDescription: (_hideDescription: boolean | undefined): void => {},
     setDisabled: (_disabled: boolean | undefined): void => {},


### PR DESCRIPTION
The type of the `setOnTaxCodeSelect` setter was added incorrectly in https://github.com/stripe/connect-js/pull/202.

The approved type from API Review is `(taxCode: string) => void`.