### PR TITLE
Add Instant payouts promotion component (GA)

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -21,6 +21,7 @@ type ConnectElementHTMLName =
   | "stripe-connect-payment-disputes"
   | "stripe-connect-account-management"
   | "stripe-connect-notification-banner"
+  | "stripe-connect-instant-payouts-promotion"
   | "stripe-connect-issuing-card"
   | "stripe-connect-issuing-cards-list"
   | "stripe-connect-financial-account"
@@ -46,6 +47,7 @@ export const componentNameMapping: Record<
   balances: "stripe-connect-balances",
   "account-management": "stripe-connect-account-management",
   "notification-banner": "stripe-connect-notification-banner",
+  "instant-payouts-promotion": "stripe-connect-instant-payouts-promotion",
   "issuing-card": "stripe-connect-issuing-card",
   "issuing-cards-list": "stripe-connect-issuing-cards-list",
   "financial-account": "stripe-connect-financial-account",

--- a/types/config.ts
+++ b/types/config.ts
@@ -222,6 +222,16 @@ export const ConnectElementCustomMethodConfig = {
         | undefined
     ): void => {},
   },
+  "instant-payouts-promotion": {
+    setOnInstantPayoutsPromotionLoaded: (
+      _listener:
+        | (({ promotionShown }: { promotionShown: boolean }) => void)
+        | undefined
+    ): void => {},
+    setOnInstantPayoutCreated: (
+      _listener: (({ payoutId }: { payoutId: string }) => void) | undefined
+    ): void => {},
+  },
   "issuing-card": {
     setDefaultCard: (_defaultCard: string | undefined): void => {},
     setCardSwitching: (_cardSwitching: boolean | undefined): void => {},

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -495,6 +495,7 @@ export type ConnectElementTagName =
   | "payment-disputes"
   | "account-management"
   | "notification-banner"
+  | "instant-payouts-promotion"
   | "issuing-card"
   | "issuing-cards-list"
   | "financial-account"


### PR DESCRIPTION
screen recording showing components rendered + setters called

https://github.com/user-attachments/assets/f23a1d9b-54ab-4f14-8490-d6b774ed2fbb

