### PR TITLE
Add Instant payouts promotion component to preview 

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -24,6 +24,7 @@ export type ConnectElementHTMLName =
   | "stripe-connect-account-management"
   | "stripe-connect-notification-banner"
   | "stripe-connect-instant-payouts"
+  | "stripe-connect-instant-payouts-promotion"
   | "stripe-connect-issuing-card"
   | "stripe-connect-issuing-cards-list"
   | "stripe-connect-financial-account"
@@ -59,6 +60,7 @@ export const componentNameMapping: Record<
   "account-management": "stripe-connect-account-management",
   "notification-banner": "stripe-connect-notification-banner",
   "instant-payouts": "stripe-connect-instant-payouts",
+  "instant-payouts-promotion": "stripe-connect-instant-payouts-promotion",
   "issuing-card": "stripe-connect-issuing-card",
   "issuing-cards-list": "stripe-connect-issuing-cards-list",
   "financial-account": "stripe-connect-financial-account",

--- a/types/config.ts
+++ b/types/config.ts
@@ -255,6 +255,16 @@ export const ConnectElementCustomMethodConfig = {
         | undefined
     ): void => {},
   },
+  "instant-payouts-promotion": {
+    setOnInstantPayoutsPromotionLoaded: (
+      _listener:
+        | (({ promotionShown }: { promotionShown: boolean }) => void)
+        | undefined
+    ): void => {},
+    setOnInstantPayoutCreated: (
+      _listener: (({ payoutId }: { payoutId: string }) => void) | undefined
+    ): void => {},
+  },
   "issuing-card": {
     setDefaultCard: (_defaultCard: string | undefined): void => {},
     setCardSwitching: (_cardSwitching: boolean | undefined): void => {},

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -497,6 +497,7 @@ export type ConnectElementTagName =
   | "account-management"
   | "notification-banner"
   | "instant-payouts"
+  | "instant-payouts-promotion"
   | "issuing-card"
   | "issuing-cards-list"
   | "financial-account"


### PR DESCRIPTION
Adding Instant payouts promotion (preview). Tested component rendering and setters locally

https://github.com/user-attachments/assets/c1b29b15-0125-419b-b285-308f6f0bc5f3

