### PR TITLE
Update type definition for setOnTaxCodeSelect setter

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -384,7 +384,7 @@ export const ConnectElementCustomMethodConfig = {
   },
   "product-tax-code-selector": {
     setOnTaxCodeSelect: (
-      _listener: ((taxCode: string) => void) | undefined
+      _listener: ((taxCode: string, { analyticsName }: { analyticsName: string }) => void) | undefined
     ): void => {},
     setHideDescription: (_hideDescription: boolean | undefined): void => {},
     setDisabled: (_disabled: boolean | undefined): void => {},


### PR DESCRIPTION
This updates the type definition for the `setOnTaxCodeSelect` setter, based on the approved API Review addendum.