### PR TITLE
Adds PayoutDetails embedded component to GA

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -28,6 +28,7 @@ type ConnectElementHTMLName =
   | "stripe-connect-financial-account-transactions"
   | "stripe-connect-payouts"
   | "stripe-connect-payouts-list"
+  | "stripe-connect-payout-details"
   | "stripe-connect-balances"
   | "stripe-connect-documents"
   | "stripe-connect-tax-registrations"
@@ -44,6 +45,7 @@ export const componentNameMapping: Record<
   "payment-disputes": "stripe-connect-payment-disputes",
   payouts: "stripe-connect-payouts",
   "payouts-list": "stripe-connect-payouts-list",
+  "payout-details": "stripe-connect-payout-details",
   balances: "stripe-connect-balances",
   "account-management": "stripe-connect-account-management",
   "notification-banner": "stripe-connect-notification-banner",

--- a/types/config.ts
+++ b/types/config.ts
@@ -283,4 +283,8 @@ export const ConnectElementCustomMethodConfig = {
     ): void => {},
     setDisplayCountries: (_countries: string[] | undefined): void => {},
   },
+  "payout-details": {
+    setPayout: (_payout: string | undefined): void => {},
+    setOnClose: (_listener: (() => void) | undefined): void => {},
+  },
 };

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -502,6 +502,7 @@ export type ConnectElementTagName =
   | "financial-account-transactions"
   | "payouts"
   | "payouts-list"
+  | "payout-details"
   | "balances"
   | "documents"
   | "tax-registrations"


### PR DESCRIPTION
Adds `PayoutDetails` embedded component to GA

<img width="1727" height="943" alt="Screenshot 2025-08-26 at 1 50 29 PM" src="https://github.com/user-attachments/assets/8f20133c-24d2-49d9-9452-8e529b45410c" />

https://github.com/user-attachments/assets/d229ae5d-5200-483f-aef5-d1debce0ffc8