### PR TITLE
Adds requirements restrictions to CollectionOptions

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -13,11 +13,13 @@ export type FetchEphemeralKeyFunction = (fetchParams: {
 export type CollectionOptions = {
   fields: "currently_due" | "eventually_due";
   futureRequirements?: "omit" | "include";
-  requirements?: {
-    only: string[];
-  } | {
-    exclude: string[];
-  };
+  requirements?:
+    | {
+        only: string[];
+      }
+    | {
+        exclude: string[];
+      };
 };
 
 export type Status =


### PR DESCRIPTION
Extends `CollectionOptions` type definition to include the ability to specify `requirements` restrictions.

The restrictions are polymorphic and can either be an array of `only` requirements or `exclude` requirements.