### PR TITLE
Improve errors when platforms use setters that are no longer supported

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -209,7 +209,9 @@ export const initStripeConnect = (
         (element as any)[method] = function (value: any) {
           stripeConnectInstance.then(() => {
             if (!this[`${method}InternalOnly`]) {
-              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js" package? Current version: _NPM_PACKAGE_VERSION_`);
+              throw new Error(
+                `Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js" package? Current version: _NPM_PACKAGE_VERSION_`
+              );
             }
 
             this[`${method}InternalOnly`](value);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -208,6 +208,10 @@ export const initStripeConnect = (
       for (const method in methods) {
         (element as any)[method] = function (value: any) {
           stripeConnectInstance.then(() => {
+            if (!this[`${method}InternalOnly`]) {
+              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using the latest version of the "@stripe/connect-js package?`);
+            }
+
             this[`${method}InternalOnly`](value);
           });
         };

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -210,7 +210,7 @@ export const initStripeConnect = (
           stripeConnectInstance.then(() => {
             if (!this[`${method}InternalOnly`]) {
               throw new Error(
-                `Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js" package? Current version: _NPM_PACKAGE_VERSION_`
+                `Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js" package? Using version: _NPM_PACKAGE_VERSION_`
               );
             }
 

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -209,7 +209,7 @@ export const initStripeConnect = (
         (element as any)[method] = function (value: any) {
           stripeConnectInstance.then(() => {
             if (!this[`${method}InternalOnly`]) {
-              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using the latest version of the "@stripe/connect-js package?`);
+              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js package? Current version: _NPM_PACKAGE_VERSION_`);
             }
 
             this[`${method}InternalOnly`](value);

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -209,7 +209,7 @@ export const initStripeConnect = (
         (element as any)[method] = function (value: any) {
           stripeConnectInstance.then(() => {
             if (!this[`${method}InternalOnly`]) {
-              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js package? Current version: _NPM_PACKAGE_VERSION_`);
+              throw new Error(`Method ${method} is not available in the ${tagName} HTML element. Are you using a supported version of the "@stripe/connect-js" package? Current version: _NPM_PACKAGE_VERSION_`);
             }
 
             this[`${method}InternalOnly`](value);


### PR DESCRIPTION
We have a platform escalation with this error:
> TypeError: this[t] is not a function at this[${t}InternalOnly](n)

This is hard to debug, because:
1. We don't know the HTML element they are using
2. We don't know the method
3. We don't know the npm package version

This PR adds a specific error so we can know all of those things next time a platform runs into this.