### PR TITLE
Add setOnAfterTaxRegistrationExpired

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -289,6 +289,9 @@ export const ConnectElementCustomMethodConfig = {
       _listener: (({ id }: { id: string }) => void) | undefined
     ): void => {},
     setDisplayCountries: (_countries: string[] | undefined): void => {},
+    setOnAfterTaxRegistrationExpired: (
+      _listener: (({ id }: { id: string }) => void) | undefined
+    ): void => {},
   },
   "payout-details": {
     setPayout: (_payout: string | undefined): void => {},


### PR DESCRIPTION
This adds the `setOnAfterTaxRegistrationExpired` setter method to the Tax Registrations embedded component, which has been approved by API Review.