### PR TITLE
Update setOnTaxCodeSelect

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -393,8 +393,8 @@ export const ConnectElementCustomMethodConfig = {
     setOnTaxCodeSelect: (
       _listener:
         | ((
-            taxCode: string,
-            { analyticsName }: { analyticsName: string }
+            taxCode: string | null,
+            _: { analyticsName: string } | null
           ) => void)
         | undefined
     ): void => {},


### PR DESCRIPTION
This updates the signature of the `setOnTaxCodeSelect` method, so `null` would get returned as a possible type for both positional arguments.

The change has been approved by an API Review addendum.