### PR TITLE
Add types for new theming tokens in preview

### DIFF
--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -5,7 +5,7 @@ import type {
   EmbeddedErrorType,
 } from "./config";
 export declare type LoadConnectAndInitialize = (
-  initParams: IStripeConnectInitParams,
+  initParams: IStripeConnectInitParams
 ) => StripeConnectInstance;
 
 export declare type OverlayOption = "dialog" | "drawer";
@@ -624,7 +624,7 @@ export interface StripeConnectInstance {
    * @returns An HTML component corresponding to that connect component
    */
   create: <T extends ConnectElementTagName>(
-    tagName: T,
+    tagName: T
   ) => ConnectHTMLElementRecord[T];
 
   /**

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -5,7 +5,7 @@ import type {
   EmbeddedErrorType,
 } from "./config";
 export declare type LoadConnectAndInitialize = (
-  initParams: IStripeConnectInitParams
+  initParams: IStripeConnectInitParams,
 ) => StripeConnectInstance;
 
 export declare type OverlayOption = "dialog" | "drawer";
@@ -144,6 +144,44 @@ export declare type AppearanceVariables = {
    */
   buttonSecondaryColorText?: string;
 
+  // Danger Button Colors
+  /**
+   * The color used as a background for danger buttons to indicate destructive actions. This accepts hex values or RGB/HSL strings.
+   */
+  buttonDangerColorBackground?: string;
+  /**
+   * The color used as a border for danger buttons to indicate destructive actions. This accepts hex values or RGB/HSL strings.
+   */
+  buttonDangerColorBorder?: string;
+  /**
+   * The text color used for danger buttons to indicate destructive actions. This accepts hex values or RGB/HSL strings.
+   */
+  buttonDangerColorText?: string;
+
+  // Button Padding
+  /**
+   * The horizontal padding used for buttons. This supports pixel values only.
+   */
+  buttonPaddingX?: string;
+  /**
+   * The vertical padding used for buttons. This supports pixel values only.
+   */
+  buttonPaddingY?: string;
+
+  // Button Label Typography
+  /**
+   * The font size for button label typography. Button label typography variables accept a valid font size value ranging from 1px to 200px, 0.1em to 12em, and 0.1rem to 12rem.
+   */
+  buttonLabelFontSize?: string;
+  /**
+   * The font weight for button label typography. Button label typography variables accept a valid font weight value.
+   */
+  buttonLabelFontWeight?: string;
+  /**
+   * The text transform for button label typography. Button label typography variables accept a valid text transform value.
+   */
+  buttonLabelTextTransform?: string;
+
   /**
    * The color used for secondary text. This accepts hex values or RGB/RGBA/HSL strings.
    */
@@ -169,6 +207,10 @@ export declare type AppearanceVariables = {
    */
   actionPrimaryTextDecorationThickness?: string;
   /**
+   * The text transform for the primary actions and links. This accepts a valid text transform value.
+   */
+  actionPrimaryTextTransform?: string;
+  /**
    * The color used for secondary actions and links. This accepts hex values or RGB/HSL strings.
    */
   actionSecondaryColorText?: string;
@@ -188,6 +230,10 @@ export declare type AppearanceVariables = {
    * The thickness of text decoration of secondary actions and links. This accepts a valid text decoration thickness value.
    */
   actionSecondaryTextDecorationThickness?: string;
+  /**
+   * The text transform for the secondary actions and links. This accepts a valid text transform value.
+   */
+  actionSecondaryTextTransform?: string;
 
   // Neutral Badge Colors
   /**
@@ -245,6 +291,30 @@ export declare type AppearanceVariables = {
    */
   badgeDangerColorBorder?: string;
 
+  // Badge Padding
+  /**
+   * The horizontal padding used for badges. This supports pixel values only.
+   */
+  badgePaddingX?: string;
+  /**
+   * The vertical padding used for badges. This supports pixel values only.
+   */
+  badgePaddingY?: string;
+
+  // Badge Label Typography
+  /**
+   * The font size for badge label typography. Badge label typography variables accept a valid font size value ranging from 1px to 200px, 0.1em to 12em, and 0.1rem to 12rem.
+   */
+  badgeLabelFontSize?: string;
+  /**
+   * The font weight for badge label typography. Badge label typography variables accept a valid font weight value.
+   */
+  badgeLabelFontWeight?: string;
+  /**
+   * The text transform for badge label typography. Badge label typography variables accept a valid text transform value.
+   */
+  badgeLabelTextTransform?: string;
+
   // Background
   /**
    * The background color used when highlighting information, like the selected row on a table or particular piece of UI. This accepts hex values or RGB/HSL strings.
@@ -269,6 +339,24 @@ export declare type AppearanceVariables = {
    * The color used for to fill in form items like checkboxes, radio buttons and switches. This accepts hex values or RGB/HSL strings.
    */
   formAccentColor?: string;
+  /**
+   * The color used for placeholder text in form items. This accepts hex values or RGB/HSL strings.
+   */
+  formPlaceholderTextColor?: string;
+  /**
+   * The horizontal padding used for input fields in forms. This supports pixel values only.
+   */
+  inputFieldPaddingX?: string;
+  /**
+   * The vertical padding used for input fields in forms. This supports pixel values only.
+   */
+  inputFieldPaddingY?: string;
+
+  // Table
+  /**
+   * The vertical padding used for table rows. This supports pixel values only.
+   */
+  tableRowPaddingY?: string;
 
   // Border Sizing
   /**
@@ -536,7 +624,7 @@ export interface StripeConnectInstance {
    * @returns An HTML component corresponding to that connect component
    */
   create: <T extends ConnectElementTagName>(
-    tagName: T
+    tagName: T,
   ) => ConnectHTMLElementRecord[T];
 
   /**


### PR DESCRIPTION
### Summary and motivation

This PR adds 18 new optional appearance variables to the AppearanceVariables type in `types/shared.d.ts` (for preview release), giving platforms more granular control over the styling of buttons, badges, forms, actions, and tables in Connect embedded components. Below is a list of all the new types added:

**Danger Button Colors**
`buttonDangerColorBackground`: background color for danger buttons
`buttonDangerColorBorder`: border color for danger buttons
`buttonDangerColorText`: text color for danger buttons

**Button Padding**
`buttonPaddingX`: horizontal padding for buttons
`buttonPaddingY`: vertical padding for buttons

**Button Label Typography**
`buttonLabelFontSize`: font size for button labels
`buttonLabelFontWeight`: font weight for button labels
`buttonLabelTextTransform`: text transform for button labels

**Action**
`actionPrimaryTextTransform`: text transform for primary actions/links
`actionSecondaryTextTransform`: text transform for secondary actions/links

**Badge Padding**
`badgePaddingX`: horizontal padding for badges (pixel values only)
`badgePaddingY`: vertical padding for badges (pixel values only)

**Badge Label Typography**
`badgeLabelFontSize`: font size for badge labels
`badgeLabelFontWeight`: font weight for badge labels
`badgeLabelTextTransform`: text transform for badge labels

**Form**
`formPlaceholderTextColor`: color for placeholder text in form items
`inputFieldPaddingX`: horizontal padding for input fields (pixel values only)
`inputFieldPaddingY`: vertical padding for input fields (pixel values only)

**Table**
`tableRowPaddingY`: vertical padding for table rows

This change only affects the type with no runtime impact.