### PR TITLE
Add balanceReport and payoutReconciliationReport embedded components

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -32,7 +32,9 @@ type ConnectElementHTMLName =
   | "stripe-connect-balances"
   | "stripe-connect-documents"
   | "stripe-connect-tax-registrations"
-  | "stripe-connect-tax-settings";
+  | "stripe-connect-tax-settings"
+  | "stripe-connect-balance-report"
+  | "stripe-connect-payout-reconciliation-report";
 
 export const componentNameMapping: Record<
   ConnectElementTagName,
@@ -58,6 +60,8 @@ export const componentNameMapping: Record<
   documents: "stripe-connect-documents",
   "tax-registrations": "stripe-connect-tax-registrations",
   "tax-settings": "stripe-connect-tax-settings",
+  balanceReport: "stripe-connect-balance-report",
+  payoutReconciliationReport: "stripe-connect-payout-reconciliation-report",
 };
 
 type StripeConnectInstanceExtended = StripeConnectInstance & {

--- a/types/config.ts
+++ b/types/config.ts
@@ -301,4 +301,7 @@ export const ConnectElementCustomMethodConfig = {
     setPayout: (_payout: string | undefined): void => {},
     setOnClose: (_listener: (() => void) | undefined): void => {},
   },
+  payoutReconciliationReport: {
+    setOnNotAvailable: (_listener: (() => void) | undefined): void => {},
+  },
 };

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -594,4 +594,6 @@ export type ConnectElementTagName =
   | "balances"
   | "documents"
   | "tax-registrations"
-  | "tax-settings";
+  | "tax-settings"
+  | "balanceReport"
+  | "payoutReconciliationReport";


### PR DESCRIPTION
Registers two new GA Connect embedded components:
- balanceReport (stripe-connect-balance-report) with no custom setters
- payoutReconciliationReport (stripe-connect-payout-reconciliation-report) with setOnNotAvailable callback


Committed-By-Agent: claude