### PR TITLE
Add `setDefaultFinancingOffer` method to ConnectElementCustomMethodConfig

### DIFF
--- a/types/config.ts
+++ b/types/config.ts
@@ -344,6 +344,9 @@ export const ConnectElementCustomMethodConfig = {
     setOnApplicationStepChange: (
       _listener: (({ step }: StepChange) => void) | undefined
     ): void => {},
+    setDefaultFinancingOffer: (
+      _defaultFinancingOffer: string | undefined
+    ): void => {},
   },
   "capital-financing-promotion": {
     setLayout: (_layout: FinancingPromotionLayoutType | undefined): void => {},


### PR DESCRIPTION
This adds the defaultFinancingOffer parameter to Capital Financing Application, allowing the platform to skip the side-by-side offer page by selecting an offer by ID to apply for.

Tested with `examples/rollup` both with and without setting the field.

<img width="1876" height="550" alt="CleanShot 2026-04-21 at 23 20 43@2x" src="https://github.com/user-attachments/assets/94e25304-eb56-40e3-87dd-9ba3df2073d3" />

<img width="1250" height="2070" alt="CleanShot 2026-04-21 at 23 21 21@2x" src="https://github.com/user-attachments/assets/08b0b6e1-15c5-4a90-9dba-34abc4bad5f3" />
