### PR TITLE
Publish new SDK versions

### DIFF
--- a/ga/package.json
+++ b/ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.3.38",
+  "version": "3.3.39",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.3.53-preview-1",
+  "version": "3.3.54-preview-1",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",


### PR DESCRIPTION
After merging `preview` and `master` in https://github.com/stripe/connect-js/pull/286, I am publishing new preview and GA versions of the SDK.