### PR TITLE
Add displayOptions, publish new version

### DIFF
--- a/ga/package.json
+++ b/ga/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/ga/src/exportedTypes/shared.ts
+++ b/ga/src/exportedTypes/shared.ts
@@ -509,7 +509,19 @@ export type IStripeConnectUpdateParams = {
    * The locale to use for the Connect instance.
    */
   locale?: string;
+
+  /**
+   * Options that affect how all embedded components under this instance render
+   */
+  displayOptions?: IStripeConnectDisplayOptions;
 };
+
+export interface IStripeConnectDisplayOptions {
+  /**
+   * Whether embedded components should show object id's in the UI
+  */
+  showObjectIds?: boolean;
+}
 
 /**
  * Initialization parameters for Connect JS. See https://stripe.com/docs/connect/get-started-connect-embedded-components#configuring-connect-js for more details.
@@ -541,6 +553,11 @@ export interface IStripeConnectInitParams {
    * An array of custom fonts, which embedded components created from a ConnectInstance can use.
    */
   fonts?: Array<CssFontSource | CustomFontSource>;
+
+  /**
+   * Options that affect how all embedded components under this instance render
+   */
+  displayOptions?: IStripeConnectDisplayOptions;
 }
 
 type ConnectElementCustomMethods = typeof ConnectElementCustomMethodConfig;

--- a/ga/src/exportedTypes/shared.ts
+++ b/ga/src/exportedTypes/shared.ts
@@ -519,7 +519,7 @@ export type IStripeConnectUpdateParams = {
 export interface IStripeConnectDisplayOptions {
   /**
    * Whether embedded components should show object id's in the UI
-  */
+   */
   showObjectIds?: boolean;
 }
 

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.4.3-preview-2",
+  "version": "3.4.4-preview-1",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.4.3-preview-1",
+  "version": "3.4.3-preview-2",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/preview/src/exportedTypes/shared.ts
+++ b/preview/src/exportedTypes/shared.ts
@@ -511,6 +511,11 @@ export type IStripeConnectUpdateParams = {
    * The locale to use for the Connect instance.
    */
   locale?: string;
+
+  /**
+   * Options that affect how all embedded components under this instance render
+   */
+  displayOptions?: IStripeConnectDisplayOptions;
 };
 
 /**
@@ -574,6 +579,13 @@ export declare type RiskSignalsCollectionEvent =
    */
   | { status: "failed"; error: RiskSignalsCollectionError };
 
+export interface IStripeConnectDisplayOptions {
+  /**
+   * Whether embedded components should show object id's in the UI
+  */
+  showObjectIds?: boolean;
+}
+
 /**
  * Initialization parameters for Connect JS. See https://stripe.com/docs/connect/get-started-connect-embedded-components#configuring-connect-js for more details.
  */
@@ -610,6 +622,11 @@ export interface IStripeConnectInitParams {
    * @param {RiskSignalsCollectionEvent} event - The risk signals collection event containing status and additional details.
    */
   onRiskSignalsCollection?: (event: RiskSignalsCollectionEvent) => void;
+
+  /**
+   * Options that affect how all embedded components under this instance render
+   */
+  displayOptions?: IStripeConnectDisplayOptions;
 }
 
 type ConnectElementCustomMethods = typeof ConnectElementCustomMethodConfig;

--- a/preview/src/exportedTypes/shared.ts
+++ b/preview/src/exportedTypes/shared.ts
@@ -582,7 +582,7 @@ export declare type RiskSignalsCollectionEvent =
 export interface IStripeConnectDisplayOptions {
   /**
    * Whether embedded components should show object id's in the UI
-  */
+   */
   showObjectIds?: boolean;
 }
 


### PR DESCRIPTION
This adds the new `displayOptions` parameter to both GA and preview SDKs.