### PR TITLE
ci: limit GITHUB_TOKEN scope to read-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This adds a `permissions: contents: read` declaration to the build workflow.

The workflow runs checkout, yarn install, lint, typecheck, and unit tests. None of these operations need write access to the repository or other GitHub API scopes. Restricting the token to read-only limits the potential impact if a dependency or action were to be compromised.

Background: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token