### PR TITLE
Improve npm publish workflow's version bump, and improve the slack message. 

### DIFF
--- a/.github/workflows/npm_release.yml
+++ b/.github/workflows/npm_release.yml
@@ -18,6 +18,7 @@ on:
           - patch
           - minor
           - major
+          - prerelease
       dry_run:
         description: 'Dry run (skip publish, push, and release)'
         required: false
@@ -37,6 +38,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.package }}" = "./ga" ] && [ "${{ inputs.version_bump }}" = "prerelease" ]; then
+            echo "❌ Cannot use 'prerelease' bump type with GA package"
+            exit 1
+          fi
+
       - uses: actions/setup-node@v4
         with:
           node-version: "18"
@@ -51,13 +59,26 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          echo "old_version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+          BUMP="${{ inputs.version_bump }}"
+          if [ "${{ inputs.package }}" = "./preview" ]; then
+            if [ "$BUMP" = "prerelease" ]; then
+              BUMP="prerelease --preid=preview"
+            else
+              BUMP="pre${BUMP} --preid=preview"
+            fi
+          fi
+
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm version ${{ inputs.version_bump }} --no-git-tag-version
+            npm version $BUMP --no-git-tag-version
           else
-            npm version ${{ inputs.version_bump }} -m "Release %s (${{ inputs.package }})"
+            npm version $BUMP -m "Release %s (${{ inputs.package }})"
           fi
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
           echo "package_name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
+          echo "variant=${{ inputs.package == './preview' && 'preview' || 'GA' }}" >> "$GITHUB_OUTPUT"
 
       - name: Publish
         if: ${{ !inputs.dry_run }}
@@ -90,5 +111,5 @@ jobs:
           webhook-type: incoming-webhook
           payload: |
             {
-              "text": "${{ inputs.dry_run && '[DRY RUN] ' || '' }}${{ job.status == 'success' && '✅' || '❌' }} NPM Release: ${{ steps.version.outputs.package_name }}@${{ steps.version.outputs.version }} (${{ inputs.version_bump }})\n${{ job.status == 'success' && 'Published successfully' || 'Release failed' }} • <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run> • Triggered by ${{ github.actor }}"
+              "text": "${{ inputs.dry_run && '[DRY RUN] ' || '' }}${{ job.status == 'success' && (inputs.dry_run && '✅' || '✅') || '❌' }} ${{ job.status == 'success' && (inputs.dry_run && format('A {0} version of `{1}` would be published: {2} → {3} ({4})', steps.version.outputs.variant, steps.version.outputs.package_name, steps.version.outputs.old_version, steps.version.outputs.version, inputs.version_bump) || format('A {0} version of `{1}` was published! {2} → {3} ({4})', steps.version.outputs.variant, steps.version.outputs.package_name, steps.version.outputs.old_version, steps.version.outputs.version, inputs.version_bump)) || format('Failed to publish a {0} version of `{1}`! {2} → {3} ({4})', steps.version.outputs.variant, steps.version.outputs.package_name, steps.version.outputs.old_version, steps.version.outputs.version, inputs.version_bump) }}\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run> • Triggered by ${{ github.actor }}"
             }


### PR DESCRIPTION
connect-js, GA, patch:

✅ A GA version of @stripe/connect-js was published! 3.4.5 → 3.4.6 (patch)
View run • Triggered by torrance-stripe

connect-js, preview, patch:

✅ A preview version of @stripe/connect-js was published! 3.4.4-preview.0 → 3.4.5-preview.0 (patch)
View run • Triggered by torrance-stripe