### PR TITLE
Add financial-account-rewards embedded component to preview package

### DIFF
--- a/preview/package.json
+++ b/preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/connect-js",
-  "version": "3.4.7-preview.0",
+  "version": "3.4.8-preview.0",
   "description": "Connect.js loading utility package (preview version)",
   "main": "dist/connect.js",
   "module": "dist/connect.esm.js",

--- a/preview/src/components/componentsAndSetters.ts
+++ b/preview/src/components/componentsAndSetters.ts
@@ -16,6 +16,7 @@ export const connectElementTagNames = [
   "issuing-card",
   "issuing-cards-list",
   "financial-account",
+  "financial-account-rewards",
   "financial-account-transactions",
   "recipients",
   "capital-financing",
@@ -347,6 +348,9 @@ export const ConnectElementCustomMethodConfig = {
     setIssuingProgram: (_issuingProgram: string | undefined): void => {},
   },
   "financial-account": {
+    setFinancialAccount: (_financialAccount: string): void => {},
+  },
+  "financial-account-rewards": {
     setFinancialAccount: (_financialAccount: string): void => {},
   },
   "financial-account-transactions": {


### PR DESCRIPTION
This PR adds the `financial-account-rewards` embedded component to the `connect-js` preview package.